### PR TITLE
Add the UV Python package and environment manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata && \
     dpkg-reconfigure --frontend noninteractive tzdata && \
     rm -rf /var/lib/apt/lists/*
 
+# 复制 uv 工具到运行阶段
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 # 复制后端可执行文件
 COPY --from=backend-builder /app/target/release/jiascheduler /app/


### PR DESCRIPTION
Added uv to provide Python environment support, since the base image did not include a Python runtime.